### PR TITLE
Added docstrings to converters.js

### DIFF
--- a/standalone/lib/converters.js
+++ b/standalone/lib/converters.js
@@ -1,6 +1,9 @@
+/**
+ * Takes a plain text sentence, returns a sentence in CoNLL-U format.
+ * @param {String} text Input text (sentence)
+ * @return {String}     Sentence in CoNLL-U format
+ */
 function plainSent2Conllu(text) {
-    /* Takes a plain text sentence, returns a sentence in CoNLL-U format. */
-
     // TODO: if there's punctuation in the middle of a sentence,
     // indices shift when drawing an arc
     // punctuation
@@ -16,7 +19,7 @@ function plainSent2Conllu(text) {
 
     // enumerating tokens
     $.each(tokens, function(i, token) {tokens[i] = (i + 1) + "\t" + token});
- 
+
     lines = lines.concat(tokens);
     sent.serial = lines.join("\n");
 
@@ -38,7 +41,10 @@ function plainSent2Conllu(text) {
     return sent.serial;
 }
 
-
+/**
+ * Takes a string in CG, converts it to CoNLL-U format.
+ * @param {String} text Input string(CG format)
+ */
 function SD2Conllu(text) {
         var newContents = [];
         newContents.push(SD2conllu(text));
@@ -49,8 +55,11 @@ function SD2Conllu(text) {
         showDataIndiv();
 }
 
+/**
+ * Takes a plain text, converts it to CoNLL-U format.
+ * @param {String} text Input text
+ */
 function plainText2Conllu(text) {
-    /* Takes plain text, converts it to CoNLL-U format. */
     console.log('plainText2Conllu() ' + text);
 
     // if text consists of several sentences, process it as imported file
@@ -72,7 +81,7 @@ function plainText2Conllu(text) {
         loadDataInIndex();
     } else {
         // If the CONTENTS is empty, then we need to fill it (this is the first time
-        // we have put something into the annotatrix and CONTENTS will be empty if 
+        // we have put something into the annotatrix and CONTENTS will be empty if
         // it's the first time
         FORMAT = "CoNLL-U";
         //console.log('plainText2Conllu() ELSE ' + text);
@@ -84,9 +93,11 @@ function plainText2Conllu(text) {
     }
 }
 
-
+/**
+ * Takes a plain text, converts it to CoNLL-U format.
+ * @param {String} text Input text
+ */
 function plainText2ConlluMod(text) {
-    /* Takes plain text, converts it to CoNLL-U format. */
     console.log('plainText2Conllu() ' + text);
 
     var corpus;
@@ -104,7 +115,7 @@ function plainText2ConlluMod(text) {
         AVAILABLESENTENCES = splitted.length;
     } else {
         // If the CONTENTS is empty, then we need to fill it (this is the first time
-        // we have put something into the annotatrix and CONTENTS will be empty if 
+        // we have put something into the annotatrix and CONTENTS will be empty if
         // it's the first time
         corpus = plainSent2Conllu(text) + "\n";
         AVAILABLESENTENCES = 1;
@@ -116,9 +127,11 @@ function plainText2ConlluMod(text) {
     loadDataInIndex();
 }
 
-
+/**
+ * Checks if the input box has > 1 sentence.
+ * @param {String} text Input text
+ */
 function conlluMultiInput(text) {
-    /* Checks if the input box has > 1 sentence. */
     if(text.match(/\n\n(#.*\n)?1\t/)) {
         console.log('conlluMultiInput()');
 
@@ -142,7 +155,11 @@ function conlluMultiInput(text) {
     }
 }
 
-
+/**
+ * Takes a string in CoNLL-U, converts it to plain text.
+ * @param {String} text Input string
+ * @return {String}     Plain text
+ */
 function conllu2plainSent(text) {
     var sent = new conllu.Sentence();
     sent.serial = text;
@@ -153,7 +170,11 @@ function conllu2plainSent(text) {
     return plain;
 }
 
-
+/**
+ * Takes a string in CoNLL-U, converts it to plain text.
+ * @param {String} content Content of input area
+ * @return {String}     Cleaned up content
+ */
 function cleanConllu(content) {
     // if we don't find any tabs, then convert >1 space to tabs
     // TODO: this should probably go somewhere else, and be more

--- a/standalone/lib/converters.js
+++ b/standalone/lib/converters.js
@@ -171,7 +171,7 @@ function conllu2plainSent(text) {
 }
 
 /**
- * Takes a string in CoNLL-U, converts it to plain text.
+ * Cleans up CoNNL-U content.
  * @param {String} content Content of input area
  * @return {String}     Cleaned up content
  */

--- a/standalone/lib/visualiser.js
+++ b/standalone/lib/visualiser.js
@@ -39,14 +39,14 @@ function conlluDraw(content) {
         zoomingEnabled: true,
         userZoomingEnabled: false,
         wheelSensitivity: 0.1,
-        layout: layout, 
+        layout: layout,
         style: CY_STYLE,
         elements: conllu2cy(sent)
     });
 
 //    if(content.split('\n').length > 10) {
-//          if(!VIEW_ENHANCED){ 
-              cleanEdges(); 
+//          if(!VIEW_ENHANCED){
+              cleanEdges();
 //          }
 //    }
 
@@ -68,7 +68,7 @@ function conlluDraw(content) {
     // console.log('[3] CURRENT_ZOOM:', CURRENT_ZOOM);
     cy.zoom(CURRENT_ZOOM);
     // console.log('[4] CURRENT_ZOOM:', CURRENT_ZOOM);
-    cy.center(); 
+    cy.center();
     $(window).bind('resize', onResize);
     $(window).bind('DOMMouseScroll wheel', onScroll);
 }
@@ -84,7 +84,7 @@ function onResize(e) {
     cy.fit();
     cy.resize();
     cy.reset();
-    
+
     CURRENT_ZOOM = cy.zoom(); // Get the current zoom factor.
 //    cy.center();
 //    CURRENT_ZOOM = cy.zoom();
@@ -102,12 +102,12 @@ function onScroll(event) {
       // console.log('SHIFT SCROLL', event.shiftKey, event.originalEvent.wheelDelta, event.originalEvent.detail, event.originalEvent.deltaY);
       if(event.originalEvent.wheelDelta > 0 || event.originalEvent.detail < 0 || event.originalEvent.deltaY < 0) { // up
           //console.log('SHIFT SCROLL', event.shiftKey, 'UP', CURRENT_ZOOM);
-          CURRENT_ZOOM += SCROLL_ZOOM_INCREMENT; 
+          CURRENT_ZOOM += SCROLL_ZOOM_INCREMENT;
           cy.zoom(CURRENT_ZOOM);
           cy.center();
       } else { //down
           //console.log('SHIFT SCROLL', event.shiftKey, 'DOWN', CURRENT_ZOOM);
-          CURRENT_ZOOM -= SCROLL_ZOOM_INCREMENT; 
+          CURRENT_ZOOM -= SCROLL_ZOOM_INCREMENT;
           cy.zoom(CURRENT_ZOOM);
           cy.center();
       }
@@ -138,11 +138,11 @@ function changeBoxSize(sent) {
 
 /**
  * Layout nodes on a grid, condense means.
- * return {Object} A tree containing formatting.
+ * @return {Object} A tree containing formatting.
  */
 function formLayout() {
-    var layout = {name: "tree", 
-                    padding: 0, 
+    var layout = {name: "tree",
+                    padding: 0,
                     nodeDimensionsIncludeLabels: false
     };
     if (VERT_ALIGNMENT) {
@@ -268,7 +268,7 @@ function createToken(graph, token, spId) {
     // handling empty form
     // if (spId) {token.form = token.lemma};
     if (token.form == undefined) {token.form = " "};
- 
+
     // TODO: We shouldn't need to hold information in multiple places
     // at least not like this.
     TREE_[token.id] = token;
@@ -309,7 +309,7 @@ function createToken(graph, token, spId) {
     if(!VIEW_ENHANCED) {
         graph = makeDependencies(token, nodeId, graph);
     }
- 
+
 
     return graph;
 }
@@ -369,17 +369,17 @@ function makeDependencies(token, nodeId, graph) {
 		}
 	}
 
-	if(deprel != "") { 
+	if(deprel != "") {
 		var res = is_udeprel(deprel);
 		if(!res[0]) {
-			// if the deprel is not valid, mark it as an error, but 
-			// don't mark it as an error if it's blank. 
+			// if the deprel is not valid, mark it as an error, but
+			// don't mark it as an error if it's blank.
 			// console.log('[2] writeDeprel @valid=false ' + deprel + ' // ' + res[1]);
 			validDep = false;
 		}
 	}
 
-	// Append ⊲ or ⊳ to indicate direction of the arc (helpful if 
+	// Append ⊲ or ⊳ to indicate direction of the arc (helpful if
 	// there are many arcs.
 	var deprelLabel = deprel;
 	if(parseInt(head) < parseInt(nodeId) && LEFT_TO_RIGHT) {
@@ -401,7 +401,7 @@ function makeDependencies(token, nodeId, graph) {
 			"length": (deprelLabel.length / 3) + "em",
 			"label": deprelLabel,
 			"ctrl": [edgeHeight, edgeHeight, edgeHeight, edgeHeight] // ARC HEIGHT STUFFS
-			
+
 		}
 		var coef = (head - nodeId);
 		if (!LEFT_TO_RIGHT) {coef *= -1}; // support for RTL
@@ -425,7 +425,7 @@ function makeDependencies(token, nodeId, graph) {
 			graph.push({"data": edgeDep, "classes": "dependency error"});
 			//console.log("makeDependencies(): error @" + deprel);
 		}
-	
+
 
                 // If dependency cycle exists, mark the cycle as red.
                 var res2 = is_depend_cycles(TREE_);
@@ -502,7 +502,7 @@ function rangeExclusive(start, finish, step) {
 		finish = start;
 		start = 0;
 	}
-	
+
 	// Validate the finish and step numbers.
 	finish = finish || 0;
 	step = step || 1;
@@ -647,7 +647,7 @@ function setEdgePosition(thisEdge, thisHeight, coef, diff) {
 	if (!LEFT_TO_RIGHT) {coef *= -1}; // support for RTL
 	if (VERT_ALIGNMENT) {edgeDep.ctrl = [45, 45, 45, 45]};
 	//if (Math.abs(coef) != 1) {coef *= defaultCoef};
-	
+
 	thisHeight *= coef;
 
 	//console.log(thisEdge);


### PR DESCRIPTION
Added docstrings to `converters.js`

Plus fixed a little mistake for docstrings in `visualiser.js`

The deletion of unnecessary spaces are due to my code editor's automatic correction of spaces and tabs. Another little extra.

For GCI task: https://codein.withgoogle.com/dashboard/task-instances/5552461358039040/