### PR TITLE
Fixes graph div sizing issues.

### DIFF
--- a/standalone/lib/conllu_table.js
+++ b/standalone/lib/conllu_table.js
@@ -179,4 +179,7 @@ function toggleCodeWindow() {
     $(".indataarea").toggle();
     $("#tabBox").toggle();
     $("#viewButton").toggle();
+    if(!VERT_ALIGNMENT) {
+        $("#cy").css("height", $(window).height()-$(".inarea").height()-80);
+    }
 }

--- a/standalone/lib/visualiser.js
+++ b/standalone/lib/visualiser.js
@@ -94,6 +94,10 @@ function onResize(e) {
 //    CURRENT_ZOOM = cy.zoom();
     console.log('[7] CURRENT_ZOOM:', CURRENT_ZOOM);
     console.log('> resize event', CURRENT_ZOOM, cy.width(), cy.height());
+
+    if(!VERT_ALIGNMENT) {
+        $("#cy").css("height", $(window).height()-$(".inarea").height()-80);
+    }
 }
 
 /**
@@ -134,9 +138,10 @@ function changeBoxSize(sent) {
         $("#cy").css("width", $(window).width()-10);
         $("#cy").css("height", (length * 50) + "px");
     } else {
-        //$("#cy").css("width", "1500px");
-        $("#cy").css("width", $(window).width()-10);
-        $("#cy").css("height", "400px");
+        // scales width according to viewport
+        $("#cy").css("width", "100%");
+        // window height - height of top area - height of controls
+        $("#cy").css("height", $(window).height()-$(".inarea").height()-80);
     }
 }
 


### PR DESCRIPTION
Fixes #191.
- Graph doesn't get cut off randomly before the bottom of the page (except for the 15px margin on the bottom which I kept so the page doesn't need to scroll horizontally).
- Graph changes size on window resize
- Graph changes size on code toggle
![graphresize](https://user-images.githubusercontent.com/13565154/34933766-fef63006-f98c-11e7-99af-40ee017f9b5b.gif)
