### PR TITLE
Added textarea rows calculation based on screen height

### DIFF
--- a/standalone/lib/conllu_table.js
+++ b/standalone/lib/conllu_table.js
@@ -6,7 +6,18 @@ var TABLE_COLUMNS_VISIBILITY = [true, true, true, true, true, true, true, true, 
 
 var tableRowsDefault = 20
 
+function calculateRows() {
+    var windowHeight = $(window).height();
+    var graphDivHeight = $('.controls').outerHeight();
+    var controlsDivHeight = $('.row').outerHeight();
+    var fontSize = $('#indata').css('font-size');
+    var lineHeight = Math.floor(parseInt(fontSize.replace('px','')) * 1.5);
+    var remainingSpace = windowHeight - graphDivHeight - controlsDivHeight - 65;
+    tableRowsDefault = parseInt(remainingSpace/lineHeight);
+}
+
 function fitTable() {
+    calculateRows();
     /* If there're less lines in conllu than the default number of rows
     in the table, fit the number of rows to the number of lines. */
     var curSentence = $("#indata").val();


### PR DESCRIPTION
Fixes #240 
This calculates the number of rows, for which the graph will be fully displayed on one page.
@ftyers
![gifff](https://user-images.githubusercontent.com/25964807/34946168-12f2f8cc-fa06-11e7-8278-13723c7856e4.gif)

