### PR TITLE
Fix pressing enter disabling navigation

### DIFF
--- a/client/gui/table.js
+++ b/client/gui/table.js
@@ -128,8 +128,8 @@ class Table {
 
     } else {
 
-      td
-        .blur()
+      td.blur()
+      $(`[col-id="${this.col}"][row-id="${this.row}"]`)
         .addClass('focused')
         .focus();
 

--- a/server/public/js/bundle.js
+++ b/server/public/js/bundle.js
@@ -13065,7 +13065,8 @@ var Table = function () {
         td.prop('contenteditable', true).focus();
       } else {
 
-        td.blur().addClass('focused').focus();
+        td.blur();
+        $('[col-id="' + this.col + '"][row-id="' + this.row + '"]').addClass('focused').focus();
       }
 
       console.log(td.prop('contenteditable'));


### PR DESCRIPTION
Fixes #328 
The selector has to be re-called because `td` was updated outside of the scope and the `const` isn't connected to the DOM anymore