### PR TITLE
Fix Autocomplete box width

### DIFF
--- a/client/graph/index.js
+++ b/client/graph/index.js
@@ -1168,7 +1168,8 @@ class Graph {
         lookup: autocompletes,
         tabDisabled: false,
         autoSelectFirst: true,
-        lookupLimit: 5
+        lookupLimit: 5,
+        width: 'flex'
       });
 
     // add the background-mute div

--- a/server/public/js/bundle.js
+++ b/server/public/js/bundle.js
@@ -9828,7 +9828,8 @@ var Graph = function () {
         lookup: autocompletes,
         tabDisabled: false,
         autoSelectFirst: true,
-        lookupLimit: 5
+        lookupLimit: 5,
+        width: 'flex'
       });
 
       // add the background-mute div


### PR DESCRIPTION
Fixes #330 
The Autocomplete (here called selfcomplete) script accepts three things for width: `auto`, `flex` or a value in `px`. `flex` makes it be based on the maximum width of the suggestions, exactly what is wanted.