### PR TITLE
Small fix to remove errors when building.

### DIFF
--- a/client/gui/table.js
+++ b/client/gui/table.js
@@ -166,7 +166,8 @@ class Table {
         .find(".fa")
         .removeClass("fa-angle-double-left fa-angle-double-right");
 
-    console.log("refresh table") this.gui.config.column_visibilities.forEach((vis, i) => {
+    console.log("refresh table");
+    this.gui.config.column_visibilities.forEach((vis, i) => {
       const column = $(`#table-data [col-id="${i}"]`);
 
       console.log(i, vis, column)

--- a/client/server.js
+++ b/client/server.js
@@ -37,8 +37,8 @@ class Server {
           this.load();
         },
         error: data => {
-          console.info("AJAX connect failed with response:",
-                       data) this.app.gui.status.error("unable to connect to server");
+          console.info("AJAX connect failed with response:", data);
+          this.app.gui.status.error("unable to connect to server");
 
           const serial = utils.storage.load();
           if (serial)


### PR DESCRIPTION
Currently due to some bad code formatting from missing semicolons, when running `npm run build`, an error occurs. This fixes it.