### PR TITLE
gulpfile.js: Fix `build-watch` command to track `notatrix/`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task("docs", done => {
 gulp.task("ico", function() { return gulp.src(["./client/favicon.png"]).pipe(gulp.dest("./server/public")); });
 
 gulp.task("watch", () => {
-  gulp.watch(["client/*.js", "client/*/*.js", "server/views/*.ejs"], gulp.parallel("js", "html", "docs"));
+  gulp.watch(["client/**/*.js", "notatrix/**/*.js", "server/views/**/*.ejs"], gulp.parallel("js", "html", "docs"));
 });
 
 gulp.task("default", gulp.parallel("js", "html", "docs", "ico"));


### PR DESCRIPTION
To use this, you should be able to just
```sh
$ npm run build-watch
```
and then go and modify any JS file in `client/` or `notatrix/`.