### PR TITLE
[Take 2] gulpfile.js: Fix `build-watch` command to track `notatrix/`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task("docs", done => {
 gulp.task("ico", function() { return gulp.src(["./client/favicon.png"]).pipe(gulp.dest("./server/public")); });
 
 gulp.task("watch", () => {
-  gulp.watch(["client/*.js", "client/*/*.js", "server/views/*.ejs"], gulp.parallel("js", "html", "docs"));
+  gulp.watch(["client/**/*.js", "notatrix/**/*.js", "server/views/**/*.ejs"], gulp.parallel("js", "html", "docs"));
 });
 
 gulp.task("default", gulp.parallel("js", "html", "docs", "ico"));


### PR DESCRIPTION
Resubmitting #455 after it was reverted in #456 (see https://github.com/jonorthwash/ud-annotatrix/pull/456#issuecomment-859220652).