### PR TITLE
fix instructions for creating super token

### DIFF
--- a/server/public/html/help.html
+++ b/server/public/html/help.html
@@ -53,7 +53,7 @@
     </tr>
     <tr>
       <td>Merge two tokens into a supertoken</td>
-      <td>Left click on a token, then press <kbd>s</kbd>, then select with an arrow, which neighbor you want to merge with it. </td>
+      <td>Left click on a token, then press <kbd>c</kbd>, then select with an arrow, which neighbor you want to merge with it. </td>
     </tr>
   </table>
 


### PR DESCRIPTION
The help page says to use "s" to create a super token, but it is actually "c". All I did was change that one letter on the help.html page